### PR TITLE
Fix pod link for script in Showterm.pm

### DIFF
--- a/lib/Dancer/Plugin/Showterm.pm
+++ b/lib/Dancer/Plugin/Showterm.pm
@@ -21,7 +21,7 @@ In your app:
 =head1 DESCRIPTION
 
 This plugin is a L<Dancer> port of the wonderful L<http://showterm.io>, which allows
-terminal screen captures taken via the UNIX tool L<http://man7.org/linux/man-pages/man1/script.1.html|script> to be 
+terminal screen captures taken via the UNIX tool L<script|http://man7.org/linux/man-pages/man1/script.1.html> to be 
 replayed in the browser. 
 
 The plugin will intercept any request for files with a F<.showterm> extension and will generate an


### PR DESCRIPTION
I saw what looked like a typo for this on metacpan.org

http://man7.org/linux/man-pages/man1/script.1.html|script 

I checked the link info on perldoc and it says the following:

Links to an absolute URL. For example, Lhttp://www.perl.org/ or L<The Perl Home Page|http://www.perl.org/>

So I swapped them.
